### PR TITLE
Don't poll queries when app is in background

### DIFF
--- a/lib/ui/widgets/itineraries/itinerary_list.dart
+++ b/lib/ui/widgets/itineraries/itinerary_list.dart
@@ -5,6 +5,7 @@ import 'package:bussit/ui/widgets/itineraries/itinerary_item.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:bussit/utils/graphql_hooks.dart';
 import 'dart:developer' as developer;
 
 import 'package:intl/intl.dart';
@@ -63,7 +64,7 @@ class ItineraryListWidget extends HookWidget {
 
 
 
-    final result = useQuery$Itinerary(
+    final result = useQueryLifecycleAware(
       Options$Query$Itinerary(
         fetchPolicy: FetchPolicy.cacheAndNetwork,
         variables: Variables$Query$Itinerary(

--- a/lib/ui/widgets/map/layers.dart
+++ b/lib/ui/widgets/map/layers.dart
@@ -7,6 +7,7 @@ import 'package:bussit/graphql/bike_query.graphql.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:collection/collection.dart';
+import 'package:bussit/utils/graphql_hooks.dart';
 import 'dart:developer' as developer;
 
 
@@ -49,7 +50,7 @@ class BikeRentalLayer extends HookWidget {
 
   @override
   Widget build(BuildContext context){
-    final result = useQuery$CityBikes(
+    final result = useQueryLifecycleAware(
       Options$Query$CityBikes(
         fetchPolicy: FetchPolicy.cacheAndNetwork,
         pollInterval: const Duration(seconds: 15),

--- a/lib/ui/widgets/stops/stop_list.dart
+++ b/lib/ui/widgets/stops/stop_list.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:bussit/api/hsl_api.dart';
+import 'package:bussit/utils/graphql_hooks.dart';
 import 'dart:developer' as developer;
 
 // Widget showin a list of stops
@@ -15,7 +16,7 @@ class StopListWidget extends HookWidget {
   @override 
   Widget build(BuildContext context) {
 
-    final result = useQuery$StopData(
+    final result = useQueryLifecycleAware(
       Options$Query$StopData(
         // fetchResults: true,
         fetchPolicy: FetchPolicy.cacheAndNetwork,

--- a/lib/utils/graphql_hooks.dart
+++ b/lib/utils/graphql_hooks.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'dart:ui';
+
+/// Like useQuery from graphql-flutter, but doesn't poll when app lifecycle is
+/// paused (i.e. in background), and polls immediately when resuming.
+///
+/// Adapted from the original useQuery source,
+/// https://github.com/zino-hofmann/graphql-flutter/blob/graphql-v5.1.0/packages/graphql_flutter/lib/src/widgets/hooks/query.dart
+QueryHookResult<TParsed> useQueryLifecycleAware<TParsed>(
+    QueryOptions<TParsed> options) {
+  final watchQueryOptions = useMemoized(
+    () => options.asWatchQueryOptions(),
+    [options],
+  );
+  final query = useWatchQuery(watchQueryOptions);
+  final snapshot = useStream(
+    query.stream,
+    initialData: query.latestResult,
+  );
+
+  // Introduced after 5.1.0. Is this important in future versions?
+  // useEffect(() {
+  //   final cleanup = query.onData(
+  //     QueryCallbackHandler(options: options).callbacks,
+  //     removeAfterInvocation: false,
+  //   );
+  //   return cleanup;
+  // }, [options, query]);
+
+  if (options.pollInterval != null) {
+    useOnAppLifecycleStateChange((previous, current) {
+      if (current == AppLifecycleState.paused ||
+          current == AppLifecycleState.detached) {
+        query.stopPolling();
+      } else {
+        // TODO: Test transitions on iOS
+        if (previous == AppLifecycleState.paused &&
+            current == AppLifecycleState.resumed) {
+          query.fetchResults();
+        }
+        if (!query.isCurrentlyPolling) {
+          query.startPolling(options.pollInterval);
+        }
+      }
+    });
+  }
+
+  return QueryHookResult(
+    result: snapshot.data!,
+    refetch: query.refetch,
+    fetchMore: query.fetchMore,
+  );
+}


### PR DESCRIPTION
Implemented via a wrapper to graphql-flutter `useWatchQuery`. Listens to `AppLifecycleState` changes, and stops/resumes polling appropriately.

Currently this will re-issue the query immediately when resuming, even if the poll interval hadn't passed in between.